### PR TITLE
Removed UUID from chat_messages

### DIFF
--- a/models.py
+++ b/models.py
@@ -178,7 +178,6 @@ class Db:
 
             cursor.execute('''CREATE TABLE IF NOT EXISTS chat_messages (
                               id INTEGER PRIMARY KEY AUTOINCREMENT,
-                              uuid TEXT UNIQUE NOT NULL,
                               room TEXT NOT NULL,
                               assignment TEXT NOT NULL,
                               username TEXT NOT NULL,


### PR DESCRIPTION
Closes #30 by removing the UUID from the chat messages since these are not sunk